### PR TITLE
Fix #73. Tell folks about our shiny Trello.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Checkout
 [the feature checklist](https://github.com/RadicalZephyr/hermit/issues/12) for
 the latest status.
 
+We also have a [Trello organization](https://trello.com/hermit4) for those so
+inclined.
+
 
 License
 -------


### PR DESCRIPTION
Add a link to our Trello organization in `README.md`.