### PR TITLE
Make sure all utility functions have a consistent naming convention.

### DIFF
--- a/lib/hermit-add
+++ b/lib/hermit-add
@@ -60,8 +60,8 @@ fi
 
 source $(dirname $0)/utilities
 
-check-git-config
-check-hermit-profile
+check_git_config
+check_hermit_profile
 
 
 REDACTING=false
@@ -82,7 +82,7 @@ do
         echo "$file is under HERMIT_ROOT"
         echo "Things get sort of weird and meta if you add"
         echo "hermit to your hermit profile."
-        if yn-prompt "Are you sure you want to add it?"; then
+        if yn_prompt "Are you sure you want to add it?"; then
             :
         else
             continue

--- a/lib/hermit-git
+++ b/lib/hermit-git
@@ -38,8 +38,8 @@ fi
 
 source $(dirname $0)/utilities
 
-check-git-config
-check-hermit-profile
+check_git_config
+check_hermit_profile
 
 echo "Current profile: $HERMIT_PROFILE"
 echo "Located at: $HERMIT_PROFILE_PATH"

--- a/lib/hermit-init
+++ b/lib/hermit-init
@@ -29,7 +29,7 @@ fi
 
 source $(dirname $0)/utilities
 
-check-git-config
+check_git_config
 
 # Check for extraneous arguments and exit with an error if they exist.
 if [ ! $# -le 1 ]; then

--- a/lib/hermit-link
+++ b/lib/hermit-link
@@ -46,7 +46,7 @@ if [ "$1" = "--complete" ]; then
     exit
 fi
 
-check-hermit-profile
+check_hermit_profile
 
 link_file () {
     basefile="$1"

--- a/lib/hermit-status
+++ b/lib/hermit-status
@@ -29,7 +29,7 @@ fi
 
 source $(dirname $0)/utilities
 
-check-hermit-profile
+check_hermit_profile
 
 echo "Hermit status:"
 echo "Using profile $HERMIT_PROFILE"

--- a/lib/hermit-unlink
+++ b/lib/hermit-unlink
@@ -30,7 +30,7 @@ if [ "$1" = "--complete" ]; then
     exit
 fi
 
-check-hermit-profile
+check_hermit_profile
 
 #Find all files in current profile
 find "$HERMIT_PROFILE_PATH" -type d -name .git -prune -o -type f -print |

--- a/lib/hermit-update
+++ b/lib/hermit-update
@@ -42,8 +42,8 @@ fi
 
 source $(dirname $0)/utilities
 
-check-git-config
-check-hermit-profile
+check_git_config
+check_hermit_profile
 
 
 REDACTING=false

--- a/lib/hermit-use
+++ b/lib/hermit-use
@@ -34,7 +34,7 @@ if [ "$1" = "--complete" ]; then
     exit
 fi
 
-check-hermit-profile
+check_hermit_profile
 
 TO_PROFILE="$1"
 

--- a/lib/utilities
+++ b/lib/utilities
@@ -116,7 +116,7 @@ remove_verbosely() {
     echo "rm: $(rm -v "$origfile" 2>&1)"
 }
 
-check-hermit-profile() {
+check_hermit_profile() {
     if [ \! -d $HERMIT_PROFILE_PATH ]; then
         echo "Your profile hasn't been initialized yet, try" \
              "running 'hermit init'"
@@ -125,7 +125,7 @@ check-hermit-profile() {
     return 0
 }
 
-check-git-config() {
+check_git_config() {
     if git config --global user.name  > /dev/null &&
        git config --global user.email > /dev/null; then
         :
@@ -139,7 +139,7 @@ check-git-config() {
     return 0
 }
 
-yn-prompt() {
+yn_prompt() {
     local ans
     local ok=0
 


### PR DESCRIPTION
Rename all instances of functions with a `-` between words to use `_` instead.